### PR TITLE
os.ex: a module to include a file/directory as a zip entry

### DIFF
--- a/lib/zipflow/data_entry.ex
+++ b/lib/zipflow/data_entry.ex
@@ -24,7 +24,7 @@ defmodule Zipflow.DataEntry do
   shouldn't use this to store large data. Consider using
   `Zipflow.Spec.StoreEntry` directly.
   """
-  @spec encode((binary -> ()), String.t, binary) :: {LFH.t, Entry.t}
+  @spec encode((binary -> ()), String.t, bitstring) :: {LFH.t, Entry.t}
   def encode(printer, name, data) do
     header  = LFH.encode(printer, name)
     payload = StoreEntry.init(printer)

--- a/lib/zipflow/os.ex
+++ b/lib/zipflow/os.ex
@@ -1,0 +1,122 @@
+defmodule Zipflow.OS do
+  @moduledoc """
+  adds files or directories on zip archives.
+  """
+
+  alias Zipflow.Stream
+
+  defp abspath(items, root) do
+    Enum.map(items, & Path.expand(&1, root))
+  end
+
+  defp maybe_add_file(context, printer, path, options) do
+    rename = Keyword.get(options, :rename, fn x -> x end)
+    file_entry(context, printer, rename.(path), path)
+  end
+
+  defp dir_loop(context, _, [], _), do: context
+  defp dir_loop(context, printer, [[] | xss], options), do: dir_loop(context, printer, xss, options)
+  defp dir_loop(context, printer, [[x | xs] | xss], options) do
+    accept = Keyword.get(options, :accept, fn _ -> true end)
+    if accept.(x) do
+      if File.dir?(x) do
+        case File.ls(x) do
+          {:ok, ys} -> dir_loop(context, printer, [abspath(ys, x) | [xs | xss]], options)
+          error     -> error
+        end
+      else
+        maybe_add_file(context, printer, x, options)
+        |> case do
+             failure = {:error, _} -> failure
+             context               -> dir_loop(context, printer, [xs | xss], options)
+           end
+      end
+    else
+      dir_loop(context, printer, [xs | xss], options)
+    end
+  end
+
+  @doc """
+  adds a directory to a zip archive.
+
+  this functions traverses the directory recursively using `File.ls/1`
+  [1]. you may control the name on the zip archive and which files to
+  include using `:rename` and `:accept` options respectively.
+
+  # options #
+
+  * `path`:
+     The directory to add;
+
+  * `options`:
+     A keyword list; valid values are:
+
+      * `rename` (default: `fn x -> x end`):
+      A function that takes a path and return a path. The returning
+      value is the name on the zip archive;
+
+      * `accept` (default: `fn _ -> true end`):
+      A function that takes a path and returns a boolean. This
+      function will be used for every path found in the directory and
+      when it returns false that file/directory will not be included
+      in the final zip archive.
+
+  # example #
+
+  ```
+  iex> devnull = fn _ -> () end
+  iex> Zipflow.Stream.init
+  ...> |> dir_entry(devnull, "/path/to/dir")
+  ...> |> Zipflow.Stream.flush(devnull)
+  ```
+
+  [1] I couldn't find support for `openat` in elixir/erlang. Thus, it
+  is very well possible that changes in the filesystem while this
+  function executes cause it to fail. Also, as there is not `readdir`
+  [as far as I can tell] depending on how `File.ls/1` returns this
+  function may need to hold the entire file tree in memory which may
+  be an issue for large/deep directories.
+  """
+  @spec dir_entry(Stream.context,
+                  (binary -> ()),
+                  Path.t,
+                  [ {:rename, (Path.t -> Path.t)},
+                    {:accept, (Path.t -> boolean)}
+                  ]
+                 ) :: Stream.context | {:error, any}
+  def dir_entry(context, printer, path, options \\ []) do
+    if File.dir?(path) do
+      dir_loop(context, printer, [[path]], options)
+    else
+      {:error, :enotdir}
+    end
+  end
+
+  @doc """
+  adds a file to a zip archive
+
+  # example #
+
+  This example adds a file named `/file/to/add` under the name
+  `foobar`. Remember to replace `devnull` by an actual printer.
+
+  ```
+  iex> devnull = fn _ -> () end
+  iex> Zipflow.Stream.init
+  ...> |> file_entry(context, devnull, "foobar", "/path/to/file")
+  ...> |> Zipflow.Stream.flush(devnull)
+  ```
+  """
+  @spec file_entry(Stream.context, (binary -> ()), Path.t, Path.t) :: Stream.context | {:error, any}
+  def file_entry(context, printer, name, path) do
+    File.open(path, [:raw, :binary, :read], fn fh ->
+      entry = Zipflow.FileEntry.encode(printer, name, fh)
+      Zipflow.Stream.entry(context, entry)
+    end)
+    |> case do
+         {:ok, success} -> success
+         failure        -> failure
+       end
+  end
+
+end

--- a/lib/zipflow/spec/entry.ex
+++ b/lib/zipflow/spec/entry.ex
@@ -1,6 +1,6 @@
 defmodule Zipflow.Spec.Entry do
 
-  @defmodule """
+  @moduledoc """
   Represents an entry in a zip archive. For example, the `StoreEntry`
   module is used to include entries with no compression.
 
@@ -8,10 +8,10 @@ defmodule Zipflow.Spec.Entry do
   then finally `finalize`
   """
 
-  @type t :: %{crc: integer, csize: non_neg_integer, usize: non_neg_integer, private: any}
+  @type t :: %{crc: integer, size: non_neg_integer, csize: non_neg_integer, usize: non_neg_integer, private: any}
 
   @doc """
-  Initializes the entry. You must provide the `output' function.
+  Initializes the entry. You must provide the 'output' function.
   """
   @callback init((binary -> ())) :: t
 
@@ -19,7 +19,7 @@ defmodule Zipflow.Spec.Entry do
   add data to this entry. this function may be invoked multiple times
   as long as you sequence the return values properly.
   """
-  @callback data(t, binary) :: t
+  @callback data(t, bitstring) :: t
 
   @doc """
   finalize this entry. the return value must be kept as it is

--- a/lib/zipflow/spec/lfh.ex
+++ b/lib/zipflow/spec/lfh.ex
@@ -1,5 +1,5 @@
 defmodule Zipflow.Spec.LFH do
-  @type t :: %{size: integer, name: String.t, n_size: integer}
+  @type t :: %{size: non_neg_integer, name: String.t, n_size: non_neg_integer}
 
 
   @moduledoc """

--- a/lib/zipflow/spec/store_entry.ex
+++ b/lib/zipflow/spec/store_entry.ex
@@ -1,5 +1,4 @@
 defmodule Zipflow.Spec.StoreEntry do
-
   @moduledoc """
   this includes data in a zip archive uncompressed. however, you
   hardly will use this directly. instead, refer to `Zipflow.DataEntry`
@@ -11,7 +10,7 @@ defmodule Zipflow.Spec.StoreEntry do
   def init(printer) do
     z   = :zlib.open
     crc = :zlib.crc32(z, <<>>)
-    %{crc: crc, csize: 0, usize: 0, private: %{z: z, printer: printer}}
+    %{crc: crc, size: 0, csize: 0, usize: 0, private: %{z: z, printer: printer}}
   end
 
   def data(ctx, data) do

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Zipflow.Mixfile do
                 links: %{"github" => "http://github.com/dgvncsz0f/zipflow"}
               ],
      description: description,
+     elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod]
   end
@@ -18,6 +19,9 @@ defmodule Zipflow.Mixfile do
   def application do
     [applications: []]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   defp deps do
     [{:dialyxir, "~> 0.3.5", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,8 @@ defmodule Zipflow.Mixfile do
   end
 
   defp deps do
-    [{:dialyxir, "~> 0.3", only: :dev},
-     {:earmark, "~> 0.1", only: :dev},
-     {:ex_doc, "~> 0.11", only: :dev}]
+    [{:dialyxir, "~> 0.3.5", only: :dev},
+     {:ex_doc, "~> 0.13", only: :dev}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"dialyxir": {:hex, :dialyxir, "0.3.3"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.5"}}
+%{"dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,0 +1,35 @@
+defmodule Test.Zipflow.Support.Helpers do
+  @moduledoc false
+
+  def ramdev(next) do
+    {:ok, dev} = File.open("", [:ram, :write, :read, :binary])
+
+    readall = fn ->
+      {:ok, 0} = :file.position(dev, 0)
+      IO.binread(dev, :all)
+    end
+
+    try do
+      next.(readall, & IO.binwrite(dev, &1))
+    after
+      :ok = File.close(dev)
+    end
+  end
+
+  def mkstemp_dir(next) do
+    tmpdir = [:erlang.unique_integer([:monotonic]),
+              :erlang.monotonic_time,
+              :erlang.system_info(:scheduler_id)
+             ]
+             |> Enum.map(&to_string/1)
+             |> Enum.join("-")
+             |> Path.expand(System.tmp_dir!)
+    File.mkdir!(tmpdir)
+    try do
+      next.(tmpdir)
+    after
+      File.rm_rf!(tmpdir)
+    end
+  end
+
+end

--- a/test/zipflow/os/os_test.exs
+++ b/test/zipflow/os/os_test.exs
@@ -1,0 +1,161 @@
+defmodule Zipflow.OSTest do
+  use ExUnit.Case, async: true
+
+  alias Zipflow.OS
+  alias Zipflow.Stream
+
+  import Test.Zipflow.Support.Helpers
+
+  test "empty directory" do
+    ramdev fn contents, printer ->
+      mkstemp_dir fn tmpdir ->
+        Stream.init
+        |> OS.dir_entry(printer, tmpdir)
+        |> Stream.flush(printer)
+      end
+
+      assert {:ok, []} == :zip.extract(contents.(), [:memory])
+    end
+  end
+
+  test "simple directory" do
+    ramdev fn contents, printer ->
+      mkstemp_dir fn tmpdir ->
+        File.touch(Path.expand("foobar", tmpdir))
+
+        Stream.init
+        |> OS.dir_entry(printer, tmpdir, [rename: & Path.relative_to(&1, tmpdir)])
+        |> Stream.flush(printer)
+      end
+
+      assert {:ok, [{'foobar', ""}]} == :zip.extract(contents.(), [:memory])
+    end
+  end
+
+  test "complex directory" do
+    ramdev fn contents, printer ->
+      blueprint = mkstemp_dir fn tmpdir ->
+        blueprint = build_dir(tmpdir, "")
+
+        Stream.init
+        |> OS.dir_entry(printer, tmpdir, [rename: & Path.relative_to(&1, tmpdir)])
+        |> Stream.flush(printer)
+
+        blueprint
+      end
+
+      blueprint = Enum.map(blueprint, & {String.to_charlist(&1), &1})
+      {:ok, zipfiles} = :zip.extract(contents.(), [:memory])
+
+      assert Enum.sort(zipfiles) == Enum.sort(blueprint)
+    end
+  end
+
+  test "rename function" do
+    encode_path = & :erlang.md5(&1) |> Base.encode16
+
+    ramdev fn contents, printer ->
+      blueprint = mkstemp_dir fn tmpdir ->
+        blueprint = build_dir(tmpdir, "")
+
+        Stream.init
+        |> OS.dir_entry(printer, tmpdir, [rename: & encode_path.(Path.relative_to(&1, tmpdir))])
+        |> Stream.flush(printer)
+
+        blueprint
+      end
+
+      blueprint = Enum.map(blueprint, & {encode_path.(&1) |> String.to_charlist, &1})
+      {:ok, zipfiles} = :zip.extract(contents.(), [:memory])
+
+      assert Enum.sort(zipfiles) == Enum.sort(blueprint)
+    end
+  end
+
+  test "accept function" do
+    ramdev fn contents, printer ->
+      blueprint = mkstemp_dir fn tmpdir ->
+        all_files = build_dir(tmpdir, "")
+        acceptset = sample(all_files, :rand.uniform(Enum.count(all_files)))
+        |> MapSet.new
+
+        Stream.init
+        |> OS.dir_entry(printer, tmpdir, [accept: & File.dir?(&1) or MapSet.member?(acceptset, Path.relative_to(&1, tmpdir)),
+                                          rename: & Path.relative_to(&1, tmpdir)])
+        |> Stream.flush(printer)
+
+        acceptset
+      end
+
+      blueprint = Enum.map(blueprint, & {String.to_charlist(&1), &1})
+      {:ok, zipfiles} = :zip.extract(contents.(), [:memory])
+
+      assert Enum.sort(zipfiles) == Enum.sort(blueprint)
+    end
+  end
+
+  defp sample(xs, samples) do
+    Enum.shuffle(xs)
+    |> Enum.take(samples)
+  end
+
+  @max_dirs 3
+  @max_files 42
+  defp build_dir(root, parent, acc \\ [], threshold \\ @max_dirs + 1) do
+    n_dirs  = :rand.uniform(@max_dirs)
+    n_files = :rand.uniform(@max_files)
+
+    dirs = 0..n_dirs
+    |> Enum.map(& "d#{&1}")
+    |> Enum.map(& Path.join(parent, &1))
+    |> Enum.take(threshold)
+
+    files = 0..n_files
+    |> Enum.map(& "f#{&1}")
+    |> Enum.map(& Path.join(parent, &1))
+
+    dirs
+    |> Enum.map(& Path.expand(&1, root))
+    |> Enum.each(&File.mkdir!/1)
+
+    files
+    |> Enum.map(& Path.expand(&1, root))
+    |> Enum.each(& File.write!(&1, Path.relative_to(&1, root)))
+
+    Enum.reduce(dirs, Enum.concat(files, acc), fn dir, acc ->
+      build_dir(root, dir, acc, threshold - 1)
+    end)
+  end
+
+  test "simple file_entry" do
+    path = __ENV__.file
+    data = File.read!(path)
+
+    ramdev fn contents, printer ->
+      Stream.init
+      |> OS.file_entry(printer, path, path)
+      |> Stream.flush(printer)
+
+      assert {:ok, [{String.to_charlist(path), data}]} == :zip.extract(contents.(), [:memory])
+    end
+  end
+
+  test "path does not exists" do
+    ramdev fn _, printer ->
+      result = Stream.init
+      |> OS.file_entry(printer, "/not/there", "/not/there")
+
+      assert {:error, :enoent} == result
+    end
+  end
+
+  test "path does not exists [dir version]" do
+    ramdev fn _, printer ->
+      result = Stream.init
+      |> OS.dir_entry(printer, "/not/there")
+
+      assert {:error, :enotdir} == result
+    end
+  end
+
+end


### PR DESCRIPTION
this includes a new module, `OS.ex` which provides `file_entry`
and `dir_entry`. These functions are used to add a file and a
directory respectively. Its use is very straightforward but
following an example:

```
iex> devnull = fn _ -> () end
iex> Zipflow.Stream.init
... |> Zipflow.OS.file_entry(devnull, "/name/on/ziparchive", "/path/on/file")
... |> Zipflow.OS.dir_entry(devnull, "/path/to/dir")
... |> Zipflow.Stream.flush(devnull)
```

Please refer to `os.ex` for more information.
