### PR TITLE
Fix compiler errors on Elixir 1.6

### DIFF
--- a/lib/zipflow/data_entry.ex
+++ b/lib/zipflow/data_entry.ex
@@ -24,7 +24,7 @@ defmodule Zipflow.DataEntry do
   shouldn't use this to store large data. Consider using
   `Zipflow.Spec.StoreEntry` directly.
   """
-  @spec encode((binary -> ()), String.t, bitstring) :: {LFH.t, Entry.t}
+  @spec encode((binary -> any), String.t, bitstring) :: {LFH.t, Entry.t}
   def encode(printer, name, data) do
     header  = LFH.encode(printer, name)
     payload = StoreEntry.init(printer)

--- a/lib/zipflow/file_entry.ex
+++ b/lib/zipflow/file_entry.ex
@@ -33,7 +33,7 @@ defmodule Zipflow.FileEntry do
   end)
   ```
   """
-  @spec encode((binary -> ()), String.t, File.io_device) :: {LFH.t, Entry.t} | {:error, String.t}
+  @spec encode((binary -> any), String.t, File.io_device) :: {LFH.t, Entry.t} | {:error, String.t}
   def encode(printer, name, fh) do
     header = LFH.encode(printer, name)
     StoreEntry.init(printer)

--- a/lib/zipflow/os.ex
+++ b/lib/zipflow/os.ex
@@ -88,7 +88,7 @@ defmodule Zipflow.OS do
   # example #
 
   ```
-  iex> devnull = fn _ -> () end
+  iex> devnull = fn _ -> nil end
   iex> Zipflow.Stream.init
   ...> |> dir_entry(devnull, "/path/to/dir")
   ...> |> Zipflow.Stream.flush(devnull)
@@ -102,7 +102,7 @@ defmodule Zipflow.OS do
   be an issue for large/deep directories.
   """
   @spec dir_entry(Stream.context,
-                  (binary -> ()),
+                  (binary -> any),
                   Path.t,
                   [ {:rename, (Path.t -> Path.t)},
                     {:accept, (Path.t -> boolean)}
@@ -126,13 +126,13 @@ defmodule Zipflow.OS do
   `foobar`. Remember to replace `devnull` by an actual printer.
 
   ```
-  iex> devnull = fn _ -> () end
+  iex> devnull = fn _ -> nil end
   iex> Zipflow.Stream.init
   ...> |> file_entry(context, devnull, "foobar", "/path/to/file")
   ...> |> Zipflow.Stream.flush(devnull)
   ```
   """
-  @spec file_entry(Stream.context, (binary -> ()), Path.t, Path.t) :: Stream.context | {:error, any}
+  @spec file_entry(Stream.context, (binary -> any), Path.t, Path.t) :: Stream.context | {:error, any}
   def file_entry(context, printer, name, path) do
     File.open(path, [:raw, :binary, :read], fn fh ->
       entry = Zipflow.FileEntry.encode(printer, name, fh)

--- a/lib/zipflow/spec/cdh.ex
+++ b/lib/zipflow/spec/cdh.ex
@@ -20,7 +20,7 @@ defmodule Zipflow.Spec.CDH do
   ...> Zipflow.Spec.CDH.encode(&IO.binwrite/1, [entry])
   ```
   """
-  @spec encode((binary -> ()), [{Zipflow.Spec.LFH.t, Zipflow.Spec.Entry.t}]) :: ()
+  @spec encode((binary -> any), [{Zipflow.Spec.LFH.t, Zipflow.Spec.Entry.t}]) :: any
   def encode(printer, contents) do
     ctx = Enum.reduce(contents, %{entries: 0, offset: 0, size: 0}, fn {hframe, dframe}, acc ->
       hdr = header(printer, acc, hframe, dframe)

--- a/lib/zipflow/spec/entry.ex
+++ b/lib/zipflow/spec/entry.ex
@@ -13,7 +13,7 @@ defmodule Zipflow.Spec.Entry do
   @doc """
   Initializes the entry. You must provide the 'output' function.
   """
-  @callback init((binary -> ())) :: t
+  @callback init((binary -> any)) :: t
 
   @doc """
   add data to this entry. this function may be invoked multiple times

--- a/lib/zipflow/spec/lfh.ex
+++ b/lib/zipflow/spec/lfh.ex
@@ -14,7 +14,7 @@ defmodule Zipflow.Spec.LFH do
   return value and use them, in order, to generate the central
   directory header.
   """
-  @spec encode((binary -> ()), String.t) :: t
+  @spec encode((binary -> any), String.t) :: t
   def encode(printer, name) do
     nsize = byte_size(name)
     frame = <<

--- a/lib/zipflow/stream.ex
+++ b/lib/zipflow/stream.ex
@@ -54,7 +54,7 @@ defmodule Zipflow.Stream do
   @doc """
   terminates the stream by including the central directory header
   """
-  @spec flush(context, (binary -> ())) :: ()
+  @spec flush(context, (binary -> any)) :: any
   def flush(context, printer) do
     CDH.encode(printer, Enum.reverse(context))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,8 @@ defmodule Zipflow.Mixfile do
   defp elixirc_paths(_),     do: ["lib"]
 
   defp deps do
-    [{:dialyxir, "~> 0.3.5", only: :dev},
-     {:ex_doc, "~> 0.13", only: :dev}]
+    [{:dialyxir, "~> 0.5.1", only: :dev},
+     {:ex_doc, "~> 0.18", only: :dev}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/test/zipflow/spec/cdh_test.exs
+++ b/test/zipflow/spec/cdh_test.exs
@@ -4,7 +4,7 @@ defmodule Zipflow.Spec.CDHTest do
   alias Zipflow.Spec.CDH
 
   test "encode returns ()" do
-    ans = CDH.encode(fn x -> assert is_binary(x); () end, [])
+    ans = CDH.encode(fn x -> assert is_binary(x); nil end, [])
     assert () == ans
   end
 

--- a/test/zipflow/spec/store_entry_test.exs
+++ b/test/zipflow/spec/store_entry_test.exs
@@ -4,7 +4,7 @@ defmodule Zipflow.Spec.StoreEntryTest do
   alias Zipflow.Spec.StoreEntry
 
   test "encode return handle" do
-    handle = StoreEntry.init(fn x -> assert is_binary(x); () end)
+    handle = StoreEntry.init(fn x -> assert is_binary(x); nil end)
     |> StoreEntry.term
 
     assert is_integer(handle[:crc])


### PR DESCRIPTION
`()` expression is no more valid in typespecs. Compilation fails like this:
```
== Compilation error in file lib/zipflow/os.ex ==
** (CompileError) lib/zipflow/os.ex:104: type '__block__'() undefined
    (stdlib) lists.erl:1338: :lists.foreach/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

In the rest of the code `()` gives warnings:
```
warning: invalid expression (). If you want to invoke or define a function, make sure there are no spaces between the function name and its arguments. If you wanted to pass an empty block, pass a value instead, such as a nil or an atom
  test/zipflow/spec/cdh_test.exs:7
```

Also upgraded outdated dependencies.